### PR TITLE
Bugfix: "Error: Cannot retrieve repository metadata (repomd.xml) for repository: base. Please verify its path and try again"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ FROM busybox:1.28.1-uclibc AS busybox
 # All of the centos build utils in one place
 FROM centos:6 AS dev_tools
 SHELL ["/usr/bin/env", "bash", "-euvxc"]
-RUN yum groupinstall -y "Development Tools"; \
+RUN sed -i 's#mirrorlist#\#mirrorlist#g' /etc/yum.repos.d/CentOS-Base.repo; \
+    sed -i 's#\#baseurl=http:\/\/mirror#baseurl=https:\/\/vault#g' /etc/yum.repos.d/CentOS-Base.repo; \
+    yum makecache; \
+    yum groupinstall -y "Development Tools"; \
     yum clean all
 
 


### PR DESCRIPTION
```
Step 5/53 : RUN yum groupinstall -y "Development Tools";     yum clean all
 ---> Running in 214f39ae0a15
yum groupinstall -y "Development Tools";     yum clean all
+ yum groupinstall -y 'Development Tools'
Loaded plugins: fastestmirror, ovl
Setting up Group Process
Error: Cannot retrieve repository metadata (repomd.xml) for repository: base. Please verify its path and try again
YumRepo Error: All mirror URLs are not using ftp, http[s] or file.
 Eg. Invalid release/repo/arch combination/
removing mirrorlist with no valid mirrors: /var/cache/yum/x86_64/6/base/mirrorlist.txt
The command '/usr/bin/env bash -euvxc yum groupinstall -y "Development Tools";     yum clean all' returned a non-zero code: 1
```


I think it's because centos 6 has EOL, so the default built-in source address is no longer valid and needs to be replaced.